### PR TITLE
Pin adobekey.py to python2 version

### DIFF
--- a/newid
+++ b/newid
@@ -13,7 +13,7 @@ fi
 wget -P container --no-clobber \
     http://download.adobe.com/pub/adobe/digitaleditions/ADE_2.0_Installer.exe \
     http://www.voidspace.org.uk/python/pycrypto-2.6.1/pycrypto-2.6.1.win32-py2.6.exe \
-    https://raw.githubusercontent.com/apprenticeharper/DeDRM_tools/master/DeDRM_plugin/adobekey.py \
+    https://raw.githubusercontent.com/apprenticeharper/DeDRM_tools/92bf51bc8f201a2d5b1e8b90b8dc033606dbcfb0/DeDRM_plugin/adobekey.py \
  || exit 1
 
 docker build --tag adobe_diged_docker .


### PR DESCRIPTION
Hi,

First of all, thank you for your work! I was about to build the same thing and this saved me a lot of time :)

After building a fresh container, `getkey` would crash as DeDRM_tools now requires Python 3. This change pins `adobekey.py` to a working Feb. 2020 version (https://github.com/apprenticeharper/DeDRM_tools/commit/92bf51bc8f201a2d5b1e8b90b8dc033606dbcfb0) which is still on Python 2.

Of course upgrading to Python 3 in the container would also work but this was a surefire fix, the choice is up to you.

Thanks!