### PR TITLE
Fix broken dependencies, update ADE, update base image, and remove VNC requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-ADE_2.0_Installer.exe
+ADE_4.5_Installer.exe
 pycrypto-2.6.1.win32-py2.6.exe
 adobekey.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,27 @@
-FROM debian:buster
+FROM ubuntu:22.04
 
-RUN sed -i 's/ main/ main contrib non-free/' /etc/apt/sources.list
-RUN dpkg --add-architecture i386 && apt-get update && apt-get install -y \
+WORKDIR /app
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8 \
+    LC_ALL=C.UTF-8
+
+RUN    dpkg --add-architecture i386
+RUN    apt-get update && apt-get -y install python3 python-is-python3 xvfb x11vnc xdotool wget tar supervisor net-tools fluxbox gnupg2 websockify novnc
+RUN    echo 'echo -n $HOSTNAME' > /root/x11vnc_password.sh && chmod +x /root/x11vnc_password.sh
+RUN    wget -O - https://dl.winehq.org/wine-builds/winehq.key | apt-key add -
+RUN    echo 'deb https://dl.winehq.org/wine-builds/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/winehq.list
+RUN    apt-get update && apt-get -y install winehq-stable=9.0.0.0~jammy-1
+RUN    mkdir /opt/wine-stable/share/wine/mono && wget -O /opt/wine-stable/share/wine/mono/wine-mono-7.0.0-x86.msi https://dl.winehq.org/wine/wine-mono/7.0.0/wine-mono-7.0.0-x86.msi
+RUN    mkdir /opt/wine-stable/share/wine/gecko && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.4-x86.msi https://dl.winehq.org/wine/wine-gecko/2.47.4/wine-gecko-2.47.4-x86.msi && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.4-x86_64.msi https://dl.winehq.org/wine/wine-gecko/2.47.4/wine-gecko-2.47.4-x86_64.msi
+RUN    apt-get -y full-upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV WINEPREFIX /app/.wine
+ENV WINEARCH win32
+ENV DISPLAY :0
+
+RUN apt-get update && apt-get install -y \
     wine \
     winetricks \
     x11vnc \
@@ -9,9 +29,11 @@ RUN dpkg --add-architecture i386 && apt-get update && apt-get install -y \
     procps \
  && rm -rf /var/lib/apt/lists/*
 
-RUN useradd --home /app --create-home app
-USER app
+RUN winetricks -q corefonts
+RUN winetricks -q dotnet40
 
-WORKDIR /app
+RUN echo "<!DOCTYPE html><html><head><meta http-equiv=\"Refresh\" content=\"0; url='vnc.html'\" /></head><body></body></html>" > /usr/share/novnc/index.html
+
+EXPOSE 8080
 
 COPY container/ .

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Adobe Digital Editions Dockerized
 =================================
 
-Runs Adobe Digital Editions 2.0.1 in a Docker container using Wine and automates
+Runs Adobe Digital Editions 4.5 in a Docker container using Wine and automates
 the downloading of e-books from ACSM files.
 
 Authorizing Adobe IDs
@@ -15,9 +15,8 @@ One might for example use the name of the person the Adobe ID belongs to.
     ./newid alice
 
 This will run a Docker container and install a fresh instance of Adobe Digital
-Editions inside. Open a VNC client of your choice
-([TigerVNC](https://tigervnc.org/) works) and connect to `localhost:5900`.
-When the script runs for the first time the Dockerfile is built before the VNC
+Editions inside. Open a web browser and connect to `localhost:8080`.
+When the script runs for the first time the Dockerfile is built before the novnc
 server starts. Be patient and retry connecting. Once you're connected you will
 likely be seeing a blackscreen. Wait for the Adobe Digital Editions installer to
 pop up and advance the installation. This should open up the application.
@@ -54,10 +53,3 @@ generated from an authorized Adobe Digital Editions installation.
 
 An optional second argument specifies the directory to put the generated key
 file and defaults to the current directory.
-
-Known Issues
-------------
-
-This was developed on Arch Linux and it turned out later it doesn't run on
-Debian 10. It will however work on Debian 11. My best guess is that it
-doesn't work with older kernels.

--- a/bookdl
+++ b/bookdl
@@ -29,7 +29,7 @@ fi
 
 for tag in $(echo $1 | sed 's/,/ /g'); do
     container=$(uuidgen)
-    docker create --name $container "adobe_diged_docker:$tag" sh run.sh >/dev/null
+    docker create --name $container -p 8080:8080 "adobe_diged_docker:$tag" sh run.sh >/dev/null
     docker cp "$2" $container:/app/in.acsm
     docker start $container >/dev/null
     uuids="$uuids $container"

--- a/container/install.sh
+++ b/container/install.sh
@@ -1,16 +1,13 @@
 export DISPLAY=:0
 Xvfb :0 -screen 0 1024x768x24 &
 x11vnc -forever &
+websockify --web /usr/share/novnc 8080 localhost:5900 &
 
-export WINEARCH=win32
-
-winetricks -q corefonts
 winetricks -q windowscodecs
-winetricks -q dotnet35sp1
 winetricks -q python26
 
 wine pycrypto-2.6.1.win32-py2.6.exe
-wine ADE_2.0_Installer.exe
+wine ADE_4.5_Installer.exe
 
 while pgrep DigitalEditions >/dev/null; do sleep 1; done
 wineserver --kill

--- a/container/run.sh
+++ b/container/run.sh
@@ -1,13 +1,14 @@
 export DISPLAY=:1
 Xvfb :1 -screen 0 1024x768x24 &
 x11vnc -forever &
+websockify --web /usr/share/novnc 8080 localhost:5900 &
 
-wine ".wine/drive_c/Program Files/Adobe/Adobe Digital Editions 2.0/DigitalEditions.exe" in.acsm &
+wine "/app/.wine/drive_c/Program Files/Adobe/Adobe Digital Editions 4.5/DigitalEditions.exe" in.acsm &
 
 n=0
 while [ $n -lt 20 ]; do
     sleep 1
-    book=$(find My\ Digital\ Editions/ -maxdepth 1 -type f ! -name welcome.epub | head -n 1)
+    book=$(find "/app/.wine/drive_c/users/root/My Documents/My Digital Editions" -maxdepth 1 -type f ! -name welcome.epub | head -n 1)
     if [ -n "$book" ]; then
         while [ $(( $(date +%s) - $(stat -c %Y "$book") )) -lt 10 ]; do sleep 1; done
         mkdir out

--- a/container/run.sh
+++ b/container/run.sh
@@ -6,7 +6,7 @@ websockify --web /usr/share/novnc 8080 localhost:5900 &
 wine "/app/.wine/drive_c/Program Files/Adobe/Adobe Digital Editions 4.5/DigitalEditions.exe" in.acsm &
 
 n=0
-while [ $n -lt 20 ]; do
+while [ $n -lt 90 ]; do
     sleep 1
     book=$(find "/app/.wine/drive_c/users/root/My Documents/My Digital Editions" -maxdepth 1 -type f ! -name welcome.epub | head -n 1)
     if [ -n "$book" ]; then

--- a/getkey
+++ b/getkey
@@ -24,8 +24,17 @@ container=$(uuidgen)
 docker run --name $container "adobe_diged_docker:$1" wine .wine/drive_c/Python26/python.exe adobekey.py
 if docker cp $container:/app/adobekey_1.der "${2:-.}/adobekey_$1.der"; then
     docker rm -f $container >/dev/null
-    exit 0
 else
     docker rm -f $container >/dev/null
     exit 1
 fi
+
+# Print out key in hex for use in dedrm.json
+if [ -f "${2:-.}/adobekey_$1.der" ]; then
+    hex_key=$(cat "${2:-.}/adobekey_$1.der" | hexdump -ve '/1 "%02x"')
+    echo "\"adeptkeys\": {"
+    echo "  \"adobekey_$1\": \"$hex_key\""
+    echo "}"
+fi
+
+exit 0

--- a/newid
+++ b/newid
@@ -11,13 +11,13 @@ if ! (echo "$1" | grep -Eq  ^[a-zA-Z0-9_][a-zA-Z0-9_.-]*$) || [ "$1" = "latest" 
 fi
 
 wget -P container --no-clobber \
-    http://download.adobe.com/pub/adobe/digitaleditions/ADE_2.0_Installer.exe \
-    http://www.voidspace.org.uk/python/pycrypto-2.6.1/pycrypto-2.6.1.win32-py2.6.exe \
-    https://raw.githubusercontent.com/apprenticeharper/DeDRM_tools/master/DeDRM_plugin/adobekey.py \
+    https://adedownload.adobe.com/pub/adobe/digitaleditions/ADE_4.5_Installer.exe \
+    https://web.archive.org/web/20150908063207/http://www.voidspace.org.uk/python/pycrypto-2.6.1/pycrypto-2.6.1.win32-py2.6.exe \
+    https://raw.githubusercontent.com/noDRM/DeDRM_tools/92bf51bc8f201a2d5b1e8b90b8dc033606dbcfb0/DeDRM_plugin/adobekey.py \
  || exit 1
 
 docker build --tag adobe_diged_docker .
 container=$(uuidgen)
-docker run -p 127.0.0.1:5900:5900 --name $container adobe_diged_docker sh install.sh
+docker run -p 8080:8080 --name $container adobe_diged_docker sh install.sh
 docker commit $container "adobe_diged_docker:$1" >/dev/null
 docker rm $container >/dev/null


### PR DESCRIPTION
This PR includes all the changes I made to get the project running on my machine. It includes the following changes:
- Update base docker image to Ubuntu 22.04 (I had issues with 24.04 at the time)
- Update ADE to 4.5
- Use noVNC to avoid dependency on a VNC client
- Download pycrypto from archive.org backup
- Download `adobekey.py` from a specific commit hash on the new DeDRM repository
- Increase waiting time in `container/run.sh` to prevent the program from exiting prematurely
- Print key to console in `getkey` to help with calibre CLI users
- Update README.md to reflect above changes